### PR TITLE
Ensure that circuits svg has width/height 100%

### DIFF
--- a/layouts/partials/circuits.svg
+++ b/layouts/partials/circuits.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 706 562" style="object-fit:cover" preserveAspectRatio="xMidYMid slice">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 706 562" style="object-fit:cover" preserveAspectRatio="xMidYMid slice" width="auto" height="auto">
   <title>
     Circuits SVG
   </title>


### PR DESCRIPTION
This PR simply sets `width` and `height` to `auto` (defaults to 100% for svg elements) in the circuits svg, this way it is properly stretched to the viewport boundaries.