### PR TITLE
Update Open Graph properties

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -28,9 +28,11 @@
 
     <!-- facebook open graph tags -->
     <meta property="og:title" content="{{ .Title }}: Design" />
-    <meta property="og:Section" content="website" />
+    <meta property="og:type" content="website" />
     <meta property="og:url" content="{{ .Permalink }}" />
     <meta property="og:site_name" content="{{ .Site.Title }}" />
+    <meta property="og:image" content="{{.Site.BaseURL}}/images/logo.jpg">
+    <meta property="og:image:alt" content="Oxide Computer Company Logo">
     <meta property="fb:admins" content="1018260045" />
     <meta property="og:description" content="{{ .Site.Params.description }}" />
 


### PR DESCRIPTION
This PR updates Open Graph properties `og:Section`, and adds `og:image` with its  corresponding `og:image:alt`.

I believe `og:Section` was supposed to be `og:type`, as I can't find any reference to `Section` in the [Open Graph Protocol](https://ogp.me/).

