### PR TITLE
Revert circuit svg with/height auto to 100%

### DIFF
--- a/layouts/partials/circuits.svg
+++ b/layouts/partials/circuits.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 706 562" style="object-fit:cover" preserveAspectRatio="xMidYMid slice" width="auto" height="auto">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 706 562" style="object-fit:cover" preserveAspectRatio="xMidYMid slice" width="100%" height="100%">
   <g class="lines" fill="none" stroke="#505050" paint-order="fill stroke markers" stroke-linecap="round" stroke-miterlimit="10">
     <path class="st0" d="M100.8 472.8l12 12v12"/>
     <path class="st0" d="M100.8 52.8l12 12 12 12 12 12 12 12 12 12 12 12 12 12 12 12h36l12 12 12 12 12 12 12 12h36l12 12 12 12 12 12 12 12 12 12v72"/>


### PR DESCRIPTION
The changes introduced in af079b4 actually throw errors that I completely missed.

Instead of `auto`, with/height attribute should be `100%`