### PR TITLE
Set theme detection before body rendering

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -39,6 +39,18 @@
     <link rel="stylesheet" href="/css/HKGrotesk.css" />
     <link rel="stylesheet" href="/css/custom.css" />
     <script src="/js/lib/modernizr-2.6.2.min.js"></script>
+    <script>
+        function selectedTheme() {
+            if (Modernizr.localstorage) {
+                return localStorage.getItem("theme");
+            }
+            return null;
+        }
+        const currentTheme = selectedTheme();
+        if (currentTheme) {
+            document.documentElement.setAttribute("data-theme", currentTheme);
+        }
+    </script>
 </head>
 
 <body>

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -9,15 +9,6 @@ function switchTheme(e) {
   localStorage.setItem("theme", theme);
 }
 
-function selectedTheme() {
-  return localStorage.getItem("theme");
-}
-
-const currentTheme = selectedTheme();
-if (currentTheme) {
-  document.documentElement.setAttribute("data-theme", currentTheme);
-}
-
 const mql = matchMedia("(prefers-color-scheme: dark)");
 if ((mql.matches && currentTheme != "light") || currentTheme === "dark") {
   themeToggle.checked = true;


### PR DESCRIPTION
Fixes #36 

If we move the theme detection before the body element is rendered, we can prevent a flash.
