### PR TITLE
Refactor theme code, add an option to forget a saved theme, and reorder content

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -39,6 +39,7 @@
     <link rel="stylesheet" href="/css/HKGrotesk.css" />
     <link rel="stylesheet" href="/css/custom.css" />
     <script src="/js/lib/modernizr-2.6.2.min.js"></script>
+    <script src="/js/custom.js"></script>
 </head>
 
 <body>
@@ -97,7 +98,6 @@
 
         gtag('config', '{{.Site.Params.google_analytics}}');
     </script>
-    <script src="/js/custom.js"></script>
 </body>
 
 </html>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -46,46 +46,57 @@
     <div class="circuit-svg">{{ partial "circuits.svg" . }}</div>
     <div class="parent">
         <main>
-            <div class="logo-link" title="Oxide Computer Company Website">
-                <div class="logo" role="img" aria-label="Oxide Computer Company logo">
-                    <a href="https://oxide.computer/" target="_blank">
-                        {{ partial "logo.svg" . }}
-                    </a>
+            <section>
+                <div class="logo-link" title="Oxide Computer Company Website">
+                    <div id="logo" role="img" aria-label="Oxide Computer Company logo">
+                        <a href="https://oxide.computer/" target="_blank">
+                            {{ partial "logo.svg" . }}
+                        </a>
+                    </div>
+                </div>
+                <h3 id="site-title">{{.Site.Title}}</h3>
+                <h1 id="site-headline">{{.Site.Params.Headline}}</h1>
+            </section>
+            <section>
+                <p id="intro">{{.Site.Params.Description}}</p>
+                <p id="apply">
+                    <span>Interested and align with our <a href="https://oxide.computer/about/">principles of operation</a>?</span>
+                    <span>
+                        Send a PR with any improvement to <a href="https://github.com/oxidecomputer/design.oxide.computer" target="_blank" rel="noreferrer noopener">this repo on GitHub</a> or <a href="https://oxide.computer/careers/product-engineering/" target="_blank">apply through our careers page</a>.
+                    </span>
+                </p>
+            </section>
+            <section>
+                {{ $contribsJ := getJSON "/data/contributors.json" }}
+                <p class="footer-piece footer-piece--separate" id="contributors">
+                    Created by
+                    <a href="https://github.com/oxidecomputer/design.oxide.computer/graphs/contributors" target="_blank"
+                        rel="noreferrer"
+                        title="Contributors to the GitHub repository design.oxide.computer by the oxidecomputer organization">{{ len $contribsJ }} contributors</a>
+                    on
+                    <a href="https://github.com/oxidecomputer/design.oxide.computer/" target="_blank" rel="noreferrer"
+                        title="GitHub repository design.oxide.computer by the oxidecomputer organization">GitHub</a>.
+                        You can see previous versions of this page via <a href="/timetravel">TimeTravel</a>.
+                    <div id="contributor-photos">
+                        {{ range sort $contribsJ ".total" "desc" }}
+                        <a href="{{.html_url}}"><img src="{{.avatar_url}}" class="avatar" title="{{.login}}" alt="{{.login}}" width="38" height="38"></a>
+                        {{ end }}
+                    </div>
+                </p>
+            </section>
+        </main>
+        <footer>
+            <div id="theme-prefs-container">
+                <div>
+                    <label class="theme-toggle" for="theme-toggle-checkbox" aria-label="Switch the theme">
+                        <input type="checkbox" id="theme-toggle-checkbox" />
+                        <span>Dark</span><div class="slider"></div><span>Light</span>
+                    </label>
+                </div>
+                <div>
+                    <button id="theme-clear-button">Clear saved theme</button>
                 </div>
             </div>
-            <h3>{{.Site.Title}}</h3>
-            <h1>{{.Site.Params.Headline}}</h1>
-            <p class="lead">{{.Site.Params.Description}}</p>
-            <p>
-                <span>Interested and align with our <a href="https://oxide.computer/about/">principles of operation</a>?</span>
-                <span>
-                    Send a PR with any improvement to <a href="https://github.com/oxidecomputer/design.oxide.computer" target="_blank" rel="noreferrer noopener">this repo on GitHub</a> or <a href="https://oxide.computer/careers/product-engineering/" target="_blank">apply through our careers page</a>.
-                </span>
-            </p>
-        </main>
-        <section id="theme-toggle-container">
-            <label class="theme-toggle" for="checkbox" aria-label="Switch the theme">
-                <input type="checkbox" id="checkbox" />
-                <div class="slider"></div>
-            </label>
-        </section>
-        <footer>
-            {{ $contribsJ := getJSON "/data/contributors.json" }}
-            <p class="footer-piece footer-piece--separate">
-                Created by
-                <a href="https://github.com/oxidecomputer/design.oxide.computer/graphs/contributors" target="_blank"
-                    rel="noreferrer"
-                    title="Contributors to the GitHub repository design.oxide.computer by the oxidecomputer organization">{{ len $contribsJ }} contributors</a>
-                on
-                <a href="https://github.com/oxidecomputer/design.oxide.computer/" target="_blank" rel="noreferrer"
-                    title="GitHub repository design.oxide.computer by the oxidecomputer organization">GitHub</a>.
-                    You can see previous versions of this page via <a href="/timetravel">TimeTravel</a>.
-                <div id="contributors">
-                {{ range sort $contribsJ ".total" "desc" }}
-                <a href="{{.html_url}}"><img src="{{.avatar_url}}" class="avatar" title="{{.login}}" alt="{{.login}}" width="38" height="38"></a>
-                {{ end }}
-                </div>
-            </p>
         </footer>
     </div>
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,3 +1,5 @@
+/* TODO: move this to SCSS and tidy up */
+
 @charset "UTF-8";
 :root {
     /* color defaults */
@@ -17,6 +19,7 @@
     --bg-color: var(--light-bg-color);
 
     /* typeface defaults */
+    --base-font: "HK Grotesk","HK Grotesk Legacy","Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
     --title-font-size: 7vw;
     --title-min-font-size: 42px;
     --title-max-font-size: 72px;
@@ -26,10 +29,12 @@
     --mobile-base-font-line-height: 22px;
     --small-font-size: 0.7em;
     --small-font-line-height: 14px;
+
     /* animations */
     --move-in-offset: 20px;
     --move-in-animation: 1s both move-in;
     --move-in-base-delay: 80ms;
+
     /* spacing */
     --small-space: 1em;
     --large-space: 2em;
@@ -71,7 +76,7 @@
 }
 
 html {
-    font-family: "HK Grotesk","HK Grotesk Legacy","Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+    font-family: var(--base-font);
 }
 
 html, body {
@@ -101,13 +106,22 @@ body {
 }
 
 main,
-#theme-toggle-container,
 footer {
     max-width: 768px;
     width: 100%;
     padding: 0 4rem;
     z-index: 1;
     background-color: var(--bg-color);
+}
+
+#theme-prefs-container {
+  display: flex;
+  vertical-align: middle;
+  text-align: center;
+}
+
+#theme-prefs-container div:first-child {
+  margin-right: 2rem;
 }
 
 main {
@@ -120,7 +134,9 @@ main {
 
 footer {
     padding-bottom: 2rem;
+    padding-top: 2rem;
     font-size: var(--small-font-size);
+    margin-top: var(--base-font-size);
 }
 
 p,
@@ -134,8 +150,6 @@ main h1 {
     font-size: var(--title-font-size);
     letter-spacing: -0.05em;
     font-weight: 800;
-    animation: var(--move-in-animation);
-    animation-delay: calc(var(--move-in-base-delay) * 4);
     text-transform: uppercase;
     margin: 0;
     line-height: 0.9;
@@ -150,7 +164,7 @@ main h1 {
 
 @media only screen and (max-height: 600px) {
     main,
-    #theme-toggle-container,
+    #theme-prefs-container,
     footer {
         width: 49%;
     }
@@ -158,10 +172,17 @@ main h1 {
 
 @media only screen and (max-width: 600px) {
     main,
-    #theme-toggle-container,
     footer {
         width: 90%;
         padding: 0 2rem;
+    }
+    #theme-prefs-container {
+      width: 90%;
+      flex-direction: column;
+    }
+    #theme-prefs-container div:first-child {
+      margin: 0;
+      margin-bottom: 1rem;
     }
     .logo-link {
         width: 4rem;
@@ -196,31 +217,8 @@ main h3::before {
     background: currentColor;
 }
 
-logo,
-main p,
-footer p {
-    animation: var(--move-in-animation);
-}
-
-main p:nth-of-type(1) {
-    animation-delay: calc(var(--move-in-base-delay) * 4);
-}
-
-main p:nth-of-type(2) {
-    animation-delay: calc(var(--move-in-base-delay) * 6);
-}
-
-main p:nth-of-type(3) {
-    animation-delay: calc(var(--move-in-base-delay) * 8);
-}
-
-footer p:nth-of-type(1) {
-    animation-delay: calc(var(--move-in-base-delay) * 12);
-}
-
-footer #contributors {
-  animation: var(--move-in-animation);
-  animation-delay: calc(var(--move-in-base-delay) * 14);
+#contributors {
+  font-size: var(--small-font-size);
 }
 
 a {
@@ -241,51 +239,56 @@ a:hover {
 
 /* Toggle Styles */
 .theme-toggle {
-  margin-top: 20px;
-  margin-bottom: 10px;
-  animation: var(--move-in-animation);
-  animation-delay: calc(var(--move-in-base-delay) * 10);
-  display: inline-block;
-  height: 24px;
   position: relative;
-  width: 44px;
+  font-size: 1rem;
 }
 
 .theme-toggle input {
   display: none;
 }
 
+.theme-toggle span {
+  line-height: calc(1rem + 6px);
+  vertical-align: middle;
+}
+
 .slider {
-  border: 1px solid var(--font-color);
   background: var(--font-color);
   cursor: pointer;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  transition: 80ms;
-  border-radius: 30px;
+  height: calc(1rem + 6px);
+  width: calc(2.5 * 1rem);
+  position: relative;
+  border-radius: calc((1rem + 6px) / 2);
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0 6px;
 }
 
 .slider:before {
   background-color: var(--bg-color);
   content: "";
   position: absolute;
+  top: 3px;
   left: 3px;
-  bottom: 3px;
-  height: 16px;
-  width: 16px;
-  transition: 100ms;
+  height: 1rem;
+  width: 1rem;
   border-radius: 50%;
+  transition: transform var(--move-in-base-delay);
 }
 
-input:checked + .slider {
-  border-color: var(--font-color);
+input:checked ~ .slider:before {
+  transform: translateX(calc(2.5 * 1rem - (6px + 1rem)));
 }
 
-input:checked + .slider:before {
-  transform: translateX(19px);
+button {
+  background-color: var(--bg-color);
+  border: 3px solid var(--font-color);
+  color: var(--font-color);
+  cursor: pointer;
+  border-radius: 30px;
+  font-family: var(--base-font);
+  font-size: 1rem;
+  padding: 0.2rem 0.6rem;
 }
 
 .circuit-svg {
@@ -346,4 +349,47 @@ input:checked + .slider:before {
   from {
     stroke-dashoffset: 20%;
   }
+}
+
+/*
+ * Page Load Animations
+ */
+
+#logo {
+  animation: var(--move-in-animation);
+}
+
+#site-title {
+  animation: var(--move-in-animation);
+  animation-delay: calc(var(--move-in-base-delay) * 2);
+}
+
+#site-headline {
+  animation: var(--move-in-animation);
+  animation-delay: calc(var(--move-in-base-delay) * 4);
+}
+
+#intro {
+  animation: var(--move-in-animation);
+  animation-delay: calc(var(--move-in-base-delay) * 6);
+}
+
+#apply {
+  animation: var(--move-in-animation);
+  animation-delay: calc(var(--move-in-base-delay) * 8);
+}
+
+#contributors {
+  animation: var(--move-in-animation);
+  animation-delay: calc(var(--move-in-base-delay) * 10);
+}
+
+#contributor-photos {
+  animation: var(--move-in-animation);
+  animation-delay: calc(var(--move-in-base-delay) * 12);
+}
+
+#theme-prefs-container {
+  animation: var(--move-in-animation);
+  animation-delay: calc(var(--move-in-base-delay) * 14);
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -252,7 +252,7 @@ a:hover {
 }
 
 .theme-toggle input {
-  display:none;
+  display: none;
 }
 
 .slider {

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -1,41 +1,93 @@
-const themeToggle = document.querySelector(
-  '.theme-toggle input[type="checkbox"]'
-);
-themeToggle.addEventListener("change", switchTheme, false);
-
-function switchTheme(e) {
-  const theme = e.target.checked ? "dark" : "light";
-  document.documentElement.setAttribute("data-theme", theme);
-  localStorage.setItem("theme", theme);
+/**
+ * Runs when the theme toggle has been changed.
+ * 
+ * Sets the theme on the document and in local storage.
+ * 
+ * @param {object} e the change event
+ */
+function changeThemeToggle(e) {
+  updateTheme(e.target.checked ? 'dark' : 'light', true);
 }
 
-function selectedTheme() {
-  return localStorage.getItem("theme");
+/**
+ * Sets the theme on the page and in local storage. 
+ * 
+ * @param {string} newTheme the new theme to be applied
+ * @param {boolean} save whether the page should save the preference for the next visit
+ */
+function updateTheme(newTheme, save) {
+  const themeToggle = document.querySelector('.theme-toggle input[type="checkbox"]');
+
+  document.documentElement.setAttribute('data-theme', newTheme);
+  if (themeToggle) themeToggle.checked = newTheme === 'dark';
+  if (save) localStorage.setItem('theme', newTheme);
 }
 
-const currentTheme = selectedTheme();
-if (currentTheme) {
-  document.documentElement.setAttribute("data-theme", currentTheme);
-}
+/**
+ * Get the user's system theme if available.
+ */
+function getSystemTheme() {
+  // Assume light as it is the system default and most old OS's only have light themes
+  const systemTheme = 'light';
 
-const mql = matchMedia("(prefers-color-scheme: dark)");
-if ((mql.matches && currentTheme != "light") || currentTheme === "dark") {
-  themeToggle.checked = true;
-}
-
-mql.addListener((e) => {
-  if (!selectedTheme()) {
-    themeToggle.checked = e.matches;
+  if (typeof window.matchMedia === 'function' && matchMedia('(prefers-color-scheme: dark)').matches) {
+    systemTheme = 'dark';
   }
-});
 
-var paths = document.querySelectorAll('.st0');
-[].forEach.call(paths, function (path) {
-  var length = path.getTotalLength();
-  path.style.transition = path.style.WebkitTransition = 'none';
-  path.style.strokeDasharray = length + ' ' + length;
-  path.style.strokeDashoffset = length;
-  path.getBoundingClientRect();
-  path.style.transition = path.style.WebkitTransition = 'stroke-dashoffset 4s ease-in-out';
-  path.style.strokeDashoffset = '0';
+  return systemTheme;
+}
+
+/**
+ * Gets the theme override from localstorage if it has been set.
+ */
+function getThemeOverride() {
+  return localStorage.getItem('theme');
+}
+
+/**
+ * Get the current theme, which is either the user's preference or the current system theme
+ */
+function getCurrentTheme() {
+  let theme = 'light';
+  const themeOverride = getThemeOverride();
+
+  if (themeOverride !== 'undefined' && themeOverride !== 'null') {
+    theme = themeOverride;
+  } else {
+    theme = getSystemTheme();
+  }
+
+  return theme;
+}
+
+// Update the theme ASAP to avoid flash
+updateTheme(getCurrentTheme(), false);
+
+window.addEventListener('load', function() {
+  // Find the theme toggle and listen for changes
+  const themeToggle = document.querySelector(
+    '.theme-toggle input[type="checkbox"]'
+  );
+  if (themeToggle) {
+    themeToggle.checked = getCurrentTheme() === 'dark';
+    themeToggle.addEventListener('change', changeThemeToggle, false);
+  }
+
+  // Listen for system theme changes (only has an effect if the user has not set a preference)
+  const mql = matchMedia('(prefers-color-scheme: dark)');
+  mql.addListener((e) => {
+    updateTheme(getCurrentTheme(), false);
+  });
+  
+  // TODO: moderinise this code
+  var paths = document.querySelectorAll('.st0');
+  [].forEach.call(paths, function (path) {
+    var length = path.getTotalLength();
+    path.style.transition = path.style.WebkitTransition = 'none';
+    path.style.strokeDasharray = length + ' ' + length;
+    path.style.strokeDashoffset = length;
+    path.getBoundingClientRect();
+    path.style.transition = path.style.WebkitTransition = 'stroke-dashoffset 4s ease-in-out';
+    path.style.strokeDashoffset = '0';
+  });
 });

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -65,12 +65,19 @@ updateTheme(getCurrentTheme(), false);
 
 window.addEventListener('load', function() {
   // Find the theme toggle and listen for changes
-  const themeToggle = document.querySelector(
-    '.theme-toggle input[type="checkbox"]'
-  );
+  const themeToggle = document.querySelector('#theme-toggle-checkbox');
   if (themeToggle) {
     themeToggle.checked = getCurrentTheme() === 'dark';
     themeToggle.addEventListener('change', changeThemeToggle, false);
+  }
+
+  // Find the theme forget button and listen for presses
+  const themeClear = document.querySelector('#theme-clear-button');
+  if (themeClear) {
+    themeClear.addEventListener('click', function() {
+      localStorage.removeItem('theme');
+      updateTheme(getCurrentTheme(), false);
+    }, false);
   }
 
   // Listen for system theme changes (only has an effect if the user has not set a preference)


### PR DESCRIPTION
This PR improves the theme code, keeping the assumption that the designer wants to pair a dark page with a light theme and vice versa. It also reorganises the content to provide a better separation of functions.

User stories affected/created:

- As a user I want to change the website theme
- As a user I want the website theme to match my system theme

New features:

- Adds an option to forget theme preference

Changes:

- Fixes animations on page load, and moves them to a separate section of the CSS for easy maintenance
- Moves the theme controls to the footer and the contributors to the body, because the contributors are part of the core content of this page while the theme controls are less important
- Replaces theme switching code with a more functional approach
- Adds error checking to theme switching code where necessary
- Moves custom script loading to the head, so there is no flash on page load when a non-default theme is loaded (supersedes https://github.com/oxidecomputer/design-site/pull/44)
- Adds documentation to custom functions