### PR TITLE
Fix circuit animation in Firefox and for JS disabled

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -326,9 +326,7 @@ input:checked + .slider:before {
 /* Lines
 
   Note, all these styles are overridden by JS as progressive enhancement.
-  This is needed to get the effect of each line animation starting and ending
-  in synchrony, because stroke-dashoffset percentages are relative to the
-  viewport instead of relative to the individual line length.
+  See static/js/custom.js
 */
 
 .st0 {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -306,7 +306,8 @@ input:checked + .slider:before {
 /* Circles */
 
 .circles {
-    animation: drawCircle 0.8s 2s both;
+    animation: drawCircle 2s 3s both;
+    -webkit-animation: drawCircle 2s 3s both;
 }
 
 .st1 {
@@ -326,24 +327,17 @@ input:checked + .slider:before {
 /* Lines */
 
 .st0 {
-    animation: drawLine 6s 10s ease-out both;
-    -webkit-animation: drawLine 6s 10s ease-out forwards;
-    transition: stroke 900ms ease-in;
+    animation: drawLine 4s 2s both;
+    -webkit-animation: drawLine 4s 2s both;
+    stroke-dasharray: 100% 100%;
+    stroke-dashoffset: 100%;
 }
 
 @keyframes drawLine {
-  to {
-    stroke-dashoffset: 0;
-  }
-}
-
-/*
- * Safari Version 13.0.3 also seems to require the from keyword in order to
- * properly render the transition, similar to the chrome and firefox renditions.
- */
-
-@-webkit-keyframes drawLine {
   from {
-    stroke-dashoffset: 20%;
+    stroke-dashoffset: 100%;
+  }
+  to {
+    stroke-dashoffset: 0%;
   }
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -323,17 +323,22 @@ input:checked + .slider:before {
   }
 }
 
+/* Lines
 
-/* Lines */
+  Note, all these styles are overridden by JS as progressive enhancement.
+  This is needed to get the effect of each line animation starting and ending
+  in synchrony, because stroke-dashoffset percentages are relative to the
+  viewport instead of relative to the individual line length.
+*/
 
 .st0 {
-    animation: drawLine 4s 2s both;
-    -webkit-animation: drawLine 4s 2s both;
-    stroke-dasharray: 100% 100%;
-    stroke-dashoffset: 100%;
+  animation: drawLineNoScript 5s ease-in-out 1s both;
+  -webkit-animation: drawLineNoScript 5s ease-in-out 1s both;
+  stroke-dasharray: 100% 100%;
+  stroke-dashoffset: 100%;
 }
 
-@keyframes drawLine {
+@keyframes drawLineNoScript {
   from {
     stroke-dashoffset: 100%;
   }

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -28,3 +28,27 @@ mql.addListener((e) => {
     themeToggle.checked = e.matches;
   }
 });
+
+var paths = document.querySelectorAll('.st0');
+var cssString = '';
+
+paths.forEach((path, i) => {
+  var length = path.getTotalLength();
+  cssString += `
+    @keyframes circuit_${i} {
+      from {
+        stroke-dashoffset: ${length}px;
+      }
+      to {
+        stroke-dashoffset: 0px;
+      }
+    }
+  `;
+  path.style.strokeDashoffset = `${length}px`;
+  path.style.strokeDasharray = `${length}px ${length}px`;
+  path.style.animation = `circuit_${i} 4s ease-in-out both`;
+});
+
+var styleElement = document.createElement('style');
+styleElement.textContent = cssString;
+document.head.appendChild(styleElement);

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -29,6 +29,17 @@ mql.addListener((e) => {
   }
 });
 
+/*
+SVG line animations - override static CSS.
+
+To fully sync up all the line animations, each line really needs to have its
+own set of keyframes using its individual line length. Percentage values for
+stroke-dashoffset and stroke-dasharray are relative to the viewport instead of
+the line length, as would be more useful here.
+
+This allows all the lines to start and finish their animations at the same time.
+*/
+
 var paths = document.querySelectorAll('.st0');
 var cssString = '';
 

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -28,14 +28,3 @@ mql.addListener((e) => {
     themeToggle.checked = e.matches;
   }
 });
-
-var paths = document.querySelectorAll('.st0');
-[].forEach.call(paths, function (path) {
-  var length = path.getTotalLength();
-  path.style.transition = path.style.WebkitTransition = 'none';
-  path.style.strokeDasharray = length + ' ' + length;
-  path.style.strokeDashoffset = length;
-  path.getBoundingClientRect();
-  path.style.transition = path.style.WebkitTransition = 'stroke-dashoffset 4s ease-in-out';
-  path.style.strokeDashoffset = '0';
-});

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -57,7 +57,7 @@ paths.forEach((path, i) => {
   `;
   path.style.strokeDashoffset = `${length}px`;
   path.style.strokeDasharray = `${length}px ${length}px`;
-  path.style.animation = `circuit_${i} 4s ease-in-out both`;
+  path.style.animation = `circuit_${i} 4s ease-in-out 1s both`;
 });
 
 var styleElement = document.createElement('style');


### PR DESCRIPTION
Existing animation does not work in FF -- the lines start with 0 extent, and snap suddenly into existence at the end of the animation period.

In addition to the Javascript animation logic for the lines, I noticed some static CSS animation code for them. Maybe this used to provide animation if JS was disabled? But currently that does not work either. I used this CSS as a starting point to make a cross-browser, CSS-only animation.

What's the real difference here that made it work cross-browser? The way the JS-based animation used to work was applying a CSS `style.transition` property to each SVG line element. My working theory is that using a full `animation` rule instead of just a transition was needed for FF, for some reason. After this change, it worked on FF, Chrome, and Safari (Mac OS tested). Not tested in Edge or IE, although Edge should be same as Chrome?

However, this change loses the uniformity of the JS animation. For `stroke-dashoffset`, percentages are (helpfully) relative to the viewport instead of relative to the total line length as you might expect. I guess this was why it was done in JS before, so that effectively each line could have its own individual keyframes such that all lines would start and finish animating all together. This is a great effect.

To get that effect back as a progressive enhancement for JS-enabled browsers, we can generate and assign keyframe animations dynamically to each line in a loop. This new JS is similar to the old code, but assigns `style.animation` instead of `style.transition`. The effect is now the same, but works in all browsers I could test -- and still gives an almost-as-nice effect even if JS is disabled.