### PR TITLE
Replace / with - in branch refs for url to work

### DIFF
--- a/static/js/timetravel.js
+++ b/static/js/timetravel.js
@@ -42,7 +42,7 @@ function changeContent() {
   // to prevent breaking when repo does not exist anymore
   const isFork = pr.head.repo && pr.head.repo.fork || false;
   const owner = pr.head.repo && pr.head.repo.owner.login || '';
-  const ref = pr.head.ref;
+  const ref = pr.head.ref.replaceAll("/", "-");
 
   // Will be: prefix-fork-owner-ref-suffix
   // Or: prefix-ref-suffix


### PR DESCRIPTION
Vercel URLs replace slashes (/) with dashes (-) in branch refs.  This change adds a similar replace All when generating the URL used for timetravel.  